### PR TITLE
Idempotently cleanup tables

### DIFF
--- a/src/com/oltpbenchmark/benchmarks/tpcc/ddls/tpcc-db2-ddl.sql
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/ddls/tpcc-db2-ddl.sql
@@ -47,7 +47,6 @@ BEGIN ATOMIC
 END @
 
 
---DROP TABLE customer@
 CREATE TABLE customer (
   c_w_id int NOT NULL,
   c_d_id int NOT NULL,
@@ -74,7 +73,6 @@ CREATE TABLE customer (
 )@
 CREATE INDEX IDX_CUSTOMER_NAME ON customer (c_w_id,c_d_id,c_last,c_first)@
 
---DROP TABLE district@
 CREATE TABLE district (
   d_w_id int NOT NULL,
   d_id int NOT NULL,
@@ -90,7 +88,6 @@ CREATE TABLE district (
   PRIMARY KEY (d_w_id,d_id)
 )@
 
---DROP TABLE history@
 CREATE TABLE history (
   h_c_id int NOT NULL,
   h_c_d_id int NOT NULL,
@@ -102,7 +99,6 @@ CREATE TABLE history (
   h_data varchar(24) NOT NULL
 )@
 
---DROP TABLE item@
 CREATE TABLE item (
   i_id int NOT NULL,
   i_name varchar(24) NOT NULL,
@@ -112,7 +108,6 @@ CREATE TABLE item (
   PRIMARY KEY (i_id)
 )@
 
---DROP TABLE new_order@
 CREATE TABLE new_order (
   no_w_id int NOT NULL,
   no_d_id int NOT NULL,
@@ -120,7 +115,6 @@ CREATE TABLE new_order (
   PRIMARY KEY (no_w_id,no_d_id,no_o_id)
 )@
 
---DROP TABLE oorder@
 CREATE TABLE oorder (
   o_w_id int NOT NULL,
   o_d_id int NOT NULL,
@@ -134,7 +128,6 @@ CREATE TABLE oorder (
   UNIQUE (o_w_id,o_d_id,o_c_id,o_id)
 )@
 
---DROP TABLE order_line@
 CREATE TABLE order_line (
   ol_w_id int NOT NULL,
   ol_d_id int NOT NULL,
@@ -149,7 +142,6 @@ CREATE TABLE order_line (
   PRIMARY KEY (ol_w_id,ol_d_id,ol_o_id,ol_number)
 )@
 
---DROP TABLE stock@
 CREATE TABLE stock (
   s_w_id int NOT NULL,
   s_i_id int NOT NULL,
@@ -171,7 +163,6 @@ CREATE TABLE stock (
   PRIMARY KEY (s_w_id,s_i_id)
 )@
 
---DROP TABLE warehouse@
 CREATE TABLE warehouse (
   w_id int NOT NULL,
   w_ytd decimal(12,2) NOT NULL,

--- a/src/com/oltpbenchmark/benchmarks/tpcc/ddls/tpcc-db2-ddl.sql
+++ b/src/com/oltpbenchmark/benchmarks/tpcc/ddls/tpcc-db2-ddl.sql
@@ -1,7 +1,53 @@
 --DECLARE CONTINUE HANDLER FOR NOT FOUND SET at_end = 1 end;
 --CONNECT TO TPCC USER db2user USING db2;
 
---DROP TABLE customer;
+
+--#SET TERMINATOR @
+
+CREATE OR REPLACE PROCEDURE db2perf_quiet_drop( IN statement VARCHAR(1000) )
+LANGUAGE SQL
+BEGIN
+  DECLARE SQLSTATE CHAR(5);
+  DECLARE NotThere    CONDITION FOR SQLSTATE '42704';
+  DECLARE NotThereSig CONDITION FOR SQLSTATE '42883';
+
+  DECLARE EXIT HANDLER FOR NotThere, NotThereSig
+  SET SQLSTATE = '     ';
+
+  SET statement = 'DROP ' || statement;
+  EXECUTE IMMEDIATE statement;
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE customer');
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE district');
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE history');
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE oorder');
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE order_line');
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE stock');
+END @
+
+BEGIN ATOMIC
+  CALL db2perf_quiet_drop('TABLE warehouse');
+END @
+
+
+--DROP TABLE customer@
 CREATE TABLE customer (
   c_w_id int NOT NULL,
   c_d_id int NOT NULL,
@@ -25,10 +71,10 @@ CREATE TABLE customer (
   c_middle char(2) NOT NULL,
   c_data varchar(500) NOT NULL,
   PRIMARY KEY (c_w_id,c_d_id,c_id)
-);
-CREATE INDEX IDX_CUSTOMER_NAME ON customer (c_w_id,c_d_id,c_last,c_first);
+)@
+CREATE INDEX IDX_CUSTOMER_NAME ON customer (c_w_id,c_d_id,c_last,c_first)@
 
---DROP TABLE district;
+--DROP TABLE district@
 CREATE TABLE district (
   d_w_id int NOT NULL,
   d_id int NOT NULL,
@@ -42,9 +88,9 @@ CREATE TABLE district (
   d_state char(2) NOT NULL,
   d_zip char(9) NOT NULL,
   PRIMARY KEY (d_w_id,d_id)
-);
+)@
 
---DROP TABLE history;
+--DROP TABLE history@
 CREATE TABLE history (
   h_c_id int NOT NULL,
   h_c_d_id int NOT NULL,
@@ -54,9 +100,9 @@ CREATE TABLE history (
   h_date timestamp NOT NULL,
   h_amount decimal(6,2) NOT NULL,
   h_data varchar(24) NOT NULL
-);
+)@
 
---DROP TABLE item;
+--DROP TABLE item@
 CREATE TABLE item (
   i_id int NOT NULL,
   i_name varchar(24) NOT NULL,
@@ -64,17 +110,17 @@ CREATE TABLE item (
   i_data varchar(50) NOT NULL,
   i_im_id int NOT NULL,
   PRIMARY KEY (i_id)
-);
+)@
 
---DROP TABLE new_order;
+--DROP TABLE new_order@
 CREATE TABLE new_order (
   no_w_id int NOT NULL,
   no_d_id int NOT NULL,
   no_o_id int NOT NULL,
   PRIMARY KEY (no_w_id,no_d_id,no_o_id)
-);
+)@
 
---DROP TABLE oorder;
+--DROP TABLE oorder@
 CREATE TABLE oorder (
   o_w_id int NOT NULL,
   o_d_id int NOT NULL,
@@ -86,9 +132,9 @@ CREATE TABLE oorder (
   o_entry_d timestamp NOT NULL,
   PRIMARY KEY (o_w_id,o_d_id,o_id),
   UNIQUE (o_w_id,o_d_id,o_c_id,o_id)
-);
+)@
 
---DROP TABLE order_line;
+--DROP TABLE order_line@
 CREATE TABLE order_line (
   ol_w_id int NOT NULL,
   ol_d_id int NOT NULL,
@@ -101,9 +147,9 @@ CREATE TABLE order_line (
   ol_quantity decimal(2,0) NOT NULL,
   ol_dist_info char(24) NOT NULL,
   PRIMARY KEY (ol_w_id,ol_d_id,ol_o_id,ol_number)
-);
+)@
 
---DROP TABLE stock;
+--DROP TABLE stock@
 CREATE TABLE stock (
   s_w_id int NOT NULL,
   s_i_id int NOT NULL,
@@ -123,9 +169,9 @@ CREATE TABLE stock (
   s_dist_09 char(24) NOT NULL,
   s_dist_10 char(24) NOT NULL,
   PRIMARY KEY (s_w_id,s_i_id)
-);
+)@
 
---DROP TABLE warehouse;
+--DROP TABLE warehouse@
 CREATE TABLE warehouse (
   w_id int NOT NULL,
   w_ytd decimal(12,2) NOT NULL,
@@ -137,4 +183,4 @@ CREATE TABLE warehouse (
   w_state char(2) NOT NULL,
   w_zip char(9) NOT NULL,
   PRIMARY KEY (w_id)
-);
+)@


### PR DESCRIPTION
This PR resolves an issue where tables cannot be dropped because they do not already exist or tables cannot be created because they already exist. These problems would throw exceptions causing the script to break early. 


A procedure is created at the top of `tpcc-db2-ddl.sql` that handles exceptions. Tables are then dropped if they exist. Finally, tables are created again. Because of this, the terminator has been set to `@`.  This logic was copied from `oltpbench/db2-tpcc-cleardb.sql`.


Version tested: 11.1 on CentOS 7 using Vagrant, Test Kitchen, and the DB2 SAMPLE database. 


Test cases performed:
- Successfully ran entire script twice in a row on a fresh database
- Successfully ran ONLY the drop table logic twice in a row a database that already had tables
- Successfully ran ONLY the create table logic on a database that did not have tables

